### PR TITLE
provide a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+colorama==0.4.6
+fuzzywuzzy==0.18.0
+pypdf==3.8.1


### PR DESCRIPTION
The project requires modules outside the standard library.  The
present compilation was identified with pipreqs (0.4.13) in a
virtual environment of Python 3.11.2 (Linux Debian 12/bookworm).